### PR TITLE
added react-camel-case

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     requireConfigFile: false,
   },
   extends: ['standard', 'standard-jsx'],
-  plugins: ['no-only-tests'],
+  plugins: ['no-only-tests', 'react-camel-case'],
   rules: {
     'jsx-quotes': ['error', 'prefer-double'],
     'object-curly-spacing': ['error', 'always'],
@@ -67,6 +67,8 @@ module.exports = {
     // http://eslint.org/docs/user-guide/configuring#configuration-based-on-glob-patterns
     'no-unused-expressions': 0,
     'no-only-tests/no-only-tests': 'error',
+
+    'react-camel-case/react-camel-case': 'error',
   },
   env: {
     browser: true,

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Install many dependencies because [eslint sucks at them](https://github.com/esli
 yarn add --dev eslint-config-nicenice
 
 # add a billion dependencies because eslint doesnt handle allow them to be wrapped up in this package. Sorry
-yarn add --dev eslint @babel/eslint-parser @babel/core eslint-config-standard eslint-config-standard-jsx eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-plugin-react eslint-plugin-no-only-tests
+yarn add --dev eslint @babel/eslint-parser @babel/core eslint-config-standard eslint-config-standard-jsx eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-plugin-react eslint-plugin-no-only-tests eslint-plugin-react-camel-case
 ```
 
 Create a `.eslintrc.js` file:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
-    "eslint-plugin-react": "^7.24.0"
+    "eslint-plugin-react": "^7.24.0",
+    "eslint-plugin-react-camel-case": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",
@@ -46,6 +47,7 @@
     "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
-    "eslint-plugin-react": "^7.24.0"
+    "eslint-plugin-react": "^7.24.0",
+    "eslint-plugin-react-camel-case": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,6 +636,11 @@ eslint-plugin-promise@^5.1.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz#fb2188fb734e4557993733b41aa1a688f46c6f24"
   integrity sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==
 
+eslint-plugin-react-camel-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-camel-case/-/eslint-plugin-react-camel-case-1.0.0.tgz#d913d5602f59e8588c65b9ba877310980900fca5"
+  integrity sha512-rj+wDvY7VkIw9EVRUcJJd/HxlWjfKE/2O0QFwovg/caieXErmHTTMNw4Q0dQ4lp2slWXdxqw7L2Y9KC2TF0umQ==
+
 eslint-plugin-react@^7.24.0:
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz#eadedfa351a6f36b490aa17f4fa9b14e842b9eb4"


### PR DESCRIPTION
Adding plugin and rule to catch non-camel cased props for React components. This is especially helpful for inline SVGs that come from design assets.